### PR TITLE
CLOUDPLAT-3162: add npm-release environment gate (pagerduty)

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -9,5 +9,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
+    environment: npm-release
     with:
       create-github-release: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/pagerduty",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "A Node.js SDK for the PagerDuty v2 API",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Adding `environment: npm-release` to the npm release workflow.